### PR TITLE
Support code_example_list_class in _config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ a div with the class `the_buttons`.
 
 Same is true for ```code_example_list_class``` which controls the class used for the ```<li>``` and ```<ul>``` tags.
 The default class is 'code-tab' which can be changed by setting:
-    code_example_list_class: my-list-class
+```
+code_example_list_class: my-list-class
+```
 in _config.yml.
 
 ### code_example

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ jekyll-code-example-tag
 =======================
 
 Provides a tag that allows you to include in your posts and pages code examples
-for multiple langagues that are kept in seperate files. Another tag allows you
+for multiple languages that are kept in separate files. Another tag allows you
 to combine all code examples that are on a page.
 
 ## Installation
@@ -45,6 +45,11 @@ a div with the class `the_buttons`.
 
 `code_example_buttons_class` defaults to 'buttons', and 
 `code_example_button_class` defaults to 'button'.
+
+Same is true for ```code_example_list_class``` which controls the class used for the ```<li>``` and ```<ul>``` tags.
+The default class is 'code-tab' which can be changed by setting:
+    code_example_list_class: my-list-class
+in _config.yml.
 
 ### code_example
 

--- a/lib/jekyll-code-example-tag.rb
+++ b/lib/jekyll-code-example-tag.rb
@@ -32,16 +32,17 @@ module Jekyll
     end
 
     def self.buttons_markup(examples, context)
-      site = context['site']
-      buttons_class = site['code_example_buttons_class'] ? site['code_example_buttons_class'] : 'buttons'
-      button_class = site['code_example_button_class'] ? site['code_example_button_class'] : 'button'
-      menu_items = ""
-      examples.each_key do |lang|
-        menu_items << "<li><a href='#' class='#{button_class}' target='#{lang}'>#{lang.capitalize}</a></li>"
-      end
+				site = context['site']
+				buttons_class = site['code_example_buttons_class'] ? site['code_example_buttons_class'] : 'buttons'
+				button_class = site['code_example_button_class'] ? site['code_example_button_class'] : 'button'
+				list_class = site['code_example_list_class'] ? site['code_example_list_class'] : 'code-tab'
+				menu_items = ""
+				examples.each_key do |lang|
+        	menu_items << "<li class='#{list_class}'><a href='#' class='#{button_class}' target='#{lang}'>#{lang.capitalize}</a></li>"
+      	end
       <<EOF
             <div class="#{buttons_class} examples">
-              <ul>
+              <ul class="#{list_class}">
                 #{menu_items}
               </ul>
             </div>
@@ -52,7 +53,7 @@ EOF
       he = HTMLEntities.new
       <<EOF
           <div class="highlight example #{language}">
-            <pre><code class="language #{language}" data-lang="#{language}">#{he.encode(content)}</code></pre>
+            <pre><code class="#{language}" data-lang="#{language}">#{he.encode(content)}</code></pre>
           </div>
 EOF
 

--- a/lib/jekyll-code-example-tag.rb
+++ b/lib/jekyll-code-example-tag.rb
@@ -32,14 +32,14 @@ module Jekyll
     end
 
     def self.buttons_markup(examples, context)
-				site = context['site']
-				buttons_class = site['code_example_buttons_class'] ? site['code_example_buttons_class'] : 'buttons'
-				button_class = site['code_example_button_class'] ? site['code_example_button_class'] : 'button'
-				list_class = site['code_example_list_class'] ? site['code_example_list_class'] : 'code-tab'
-				menu_items = ""
-				examples.each_key do |lang|
-        	menu_items << "<li class='#{list_class}'><a href='#' class='#{button_class}' target='#{lang}'>#{lang.capitalize}</a></li>"
-      	end
+      site = context['site']
+      buttons_class = site['code_example_buttons_class'] ? site['code_example_buttons_class'] : 'buttons'
+      button_class = site['code_example_button_class'] ? site['code_example_button_class'] : 'button'
+      list_class = site['code_example_list_class'] ? site['code_example_list_class'] : 'code-tab'
+      menu_items = ""
+      examples.each_key do |lang|
+	    menu_items << "<li class='#{list_class}'><a href='#' class='#{button_class}' target='#{lang}'>#{lang.capitalize}</a></li>"
+      end
       <<EOF
             <div class="#{buttons_class} examples">
               <ul class="#{list_class}">


### PR DESCRIPTION
Also, for the ```<code>``` tag, use class="#{language}" instead of class="#{language}", this make it possible to use the CSS from https://github.com/isagalaev/highlight.js and other similar projects, without having to make any changes.
